### PR TITLE
Organization and Vale Edits

### DIFF
--- a/content/knowledge-base/integrations/vault-as-secret-store.md
+++ b/content/knowledge-base/integrations/vault-as-secret-store.md
@@ -4,69 +4,79 @@ weight: 230
 ---
 
 This guide walks through the steps required to configure Crossplane and
-its Providers to use [Vault] as an [External Secret Store]. For the sake of
-completeness, we will also include steps for Vault installation and setup,
-however, you can skip those and use your existing Vault.
+its Providers to use [Vault] as an [External Secret Store] (`ESS`) with [ESS Plugin Vault].
 
-> External Secret Stores are an alpha feature. They are not yet recommended for
-> production use, and are disabled by default.
+{{<hint "warning" >}}
+External Secret Stores are an alpha feature. 
 
-Crossplane consumes and also produces sensitive information to operate which
-could be categorized as follows:
+They're not recommended for production use. Crossplane disables External Secret
+Stores by default.
+{{< /hint >}}
 
-1. **Provider credentials:** These are the credentials required for Providers
-to authenticate against external APIs. For example, AWS Access/Secret keys, GCP
-service account json, etc.
-2. **Connection Details:** Once an infrastructure provisioned, we usually
-need some connection data to consume it. Most of the time, this
-information includes sensitive information like usernames, passwords or access
-keys. 
-3. **Sensitive Inputs to Managed Resources:** There are some Managed resources
-which expect input parameters that could be sensitive. Initial password of a
-managed database is a good example of this category.
+Crossplane uses sensitive information including Provider credentials, inputs to
+managed resources and connection details.
 
-It is already possible to use Vault for the 1st category (i.e. Provider
-Credentials) as described in [the previous guide]. The 3rd use case is relatively
-rare and being tracked with [this issue].
+The [Vault credential injection guide]({{<ref "vault-injection" >}}) details 
+using Vault and Crossplane for Provider credentials.
 
-In this guide we will focus on the 2nd category, which is storing Connection
-Details for managed resources in Vault.
+Crossplane doesn't support for using Vault for managed resources input.
+[Crossplane issue #2985](https://github.com/crossplane/crossplane/issues/2985)
+tracks support for this feature.
 
-## Steps
+Supporting connection details with Vault requires a Crossplane external secret
+store.
 
-> Some steps in this guide duplicates [the previous guide] on Vault injection.
-> However, for convenience, we put them here as well with minor
-> changes/improvements.
+## Prerequisites
+This guide requires [Helm](https://helm.sh) version 3.11 or later.
 
-At a high level we will run the following steps:
+## Install Vault
 
-- Install and Unseal Vault.
-- Configure Vault with Kubernetes Auth.
-- Install and Configure Crossplane by enabling the feature.
-- Install and Configure Provider GCP by enabling the feature.
-- Deploy a Composition and CompositeResourceDefinition.
-- Create a Claim.
-- Verify all secrets land in Vault as expected.
+{{<hint "note" >}}
+Detailed instructions on [installing
+Vault](https://developer.hashicorp.com/vault/docs/platform/k8s/helm) 
+are available from the Vault documentation.
+{{< /hint >}}
 
-For simplicity, we will deploy Vault into the same cluster as Crossplane,
-however, this is not a requirement as long as Vault has Kubernetes auth enabled
-for the cluster where Crossplane is running.
+### Add the Vault Helm chart
 
-### Prepare Vault
-
-1. Install Vault Helm Chart
-
-Add the Vault Helm chart.
+Add the Hashicorp Helm repository.
 ```shell
 helm repo add hashicorp https://helm.releases.hashicorp.com --force-update 
 ```
 
-Install Vault.
+Install Vault using Helm.
 ```shell
-helm -n vault-system --create-namespace upgrade --install vault hashicorp/vault
+helm -n vault-system upgrade --install vault hashicorp/vault --create-namespace
 ```
 
-2. [Unseal] Vault
+{{< hint "tip" >}}
+Vault requires a [Persistent Volume](https://kubernetes.io/docs/concepts/storage/persistent-volumes). 
+
+The Vault pod doesn't start without an available persistent volume.
+
+{{< expand "An example persistent volume" >}}
+```yaml
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: persistent-volume
+spec:
+  capacity:
+   storage: 10Gi
+  accessModes:
+   - ReadWriteOnce
+  hostPath:
+    path: "/tmp/vault"
+```
+{{< /expand >}}
+
+{{< /hint >}}
+
+
+### Unseal Vault
+
+If Vault is [sealed](https://developer.hashicorp.com/vault/docs/concepts/seal)
+unseal Vault using the unseal keys.
 
 Get the Vault keys.
 ```shell
@@ -75,63 +85,109 @@ VAULT_UNSEAL_KEY=$(cat cluster-keys.json | jq -r ".unseal_keys_b64[]")
 ```
 
 Unseal the vault using the keys.
-```shell
+```shell {copy-lines="1"}
 kubectl -n vault-system exec vault-0 -- vault operator unseal $VAULT_UNSEAL_KEY
+Key             Value
+---             -----
+Seal Type       shamir
+Initialized     true
+Sealed          false
+Total Shares    1
+Threshold       1
+Version         1.13.1
+Build Date      2023-03-23T12:51:35Z
+Storage Type    file
+Cluster Name    vault-cluster-df884357
+Cluster ID      b3145d26-2c1a-a7f2-a364-81753033c0d9
+HA Enabled      false
 ```
 
-1. Configure Vault with Kubernetes Auth.
+## Configure Vault Kubernetes authentication
 
-In order for Vault to be able to authenticate requests based on Kubernetes 
-service accounts, the [Kubernetes auth method] must be enabled.
-This requires logging in to Vault and configuring it with a service account
-token, API server address, and certificate. Because we are running Vault in
-Kubernetes, these values are already available via the container filesystem and
-environment variables.
+Enable the [Kubernetes auth method] for Vault to authenticate requests based on
+Kubernetes service accounts.
 
-Get Vault Root Token:
+### Get the Vault root token
+
+The Vault root token is inside the JSON file created when 
+[unsealing Vault](#unseal-vault).
 
 ```shell
 cat cluster-keys.json | jq -r ".root_token"
 ```
 
-Login as root and enable/configure Kubernetes Auth:
+### Enable Kubernetes authentication
 
-```shell
+Connect to a shell in the Vault pod.
+
+```shell {copy-lines="1"}
 kubectl -n vault-system exec -it vault-0 -- /bin/sh
+/ $
 ```
 
-Login to vault.
-```shell
-vault login # use root token from above
+From the Vault shell, login to Vault using the _root token_.
+```shell {copy-lines="1"}
+vault login # use the root token from above
+Token (will be hidden):
+Success! You are now authenticated. The token information displayed below
+is already stored in the token helper. You do NOT need to run "vault login"
+again. Future Vault requests will automatically use this token.
+
+Key                  Value
+---                  -----
+token                hvs.TSN4SssfMBM0HAtwGrxgARgn
+token_accessor       qodxHrINVlRXKyrGeeDkxnih
+token_duration       ∞
+token_renewable      false
+token_policies       ["root"]
+identity_policies    []
+policies             ["root"]
 ```
 
-Enable the Kubernetes authentication method.
-```shell
+Enable the Kubernetes authentication method in Vault.
+```shell {copy-lines="1"}
 vault auth enable kubernetes
+Success! Enabled kubernetes auth method at: kubernetes/
 ```
 
-Configure Vault to talk to Kubernetes.
-```shell
+Configure Vault to communicate with Kubernetes and exit the Vault shell
+
+```shell {copy-lines="1-4"}
 vault write auth/kubernetes/config \
         token_reviewer_jwt="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
         kubernetes_host="https://$KUBERNETES_PORT_443_TCP_ADDR:443" \
         kubernetes_ca_cert=@/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+Success! Data written to: auth/kubernetes/config
+/ $ exit
 ```
 
-4. Enable Vault Key Value Secret Engine
+## Configure Vault for Crossplane integration
 
-There are two different versions of [Vault KV Secrets Engine], `v1` and `v2`,
-which you can find more details in the linked documentation page. 
-We will use `v2` in this guide as an example, however, both versions are
-supported as an external secret store.
+Crossplane relies on the Vault key-value secrets engine to store information and
+Vault requires a permissions policy for the Crossplane service account.
 
-```shell
+<!-- vale Crossplane.Spelling = NO -->
+<!-- allow "kv" -->
+### Enable the Vault kv secrets engine
+<!-- vale Crossplane.Spelling = YES -->
+
+Enable the [Vault KV Secrets Engine].
+
+{{< hint "important" >}}
+Vault has two versions of the 
+[KV Secrets Engine](https://developer.hashicorp.com/vault/docs/secrets/kv).
+This example uses version 2.
+{{</hint >}}
+
+```shell {copy-lines="1"}
 kubectl -n vault-system exec -it vault-0 -- vault secrets enable -path=secret kv-v2
+Success! Enabled the kv-v2 secrets engine at: secret/
 ```
 
-5. Create a Vault Policy and Role for Crossplane
+### Create a Vault policy for Crossplane
 
-```shell
+Create the Vault policy to allow Crossplane to read and write data from Vault.
+```shell {copy-lines="1-8"}
 kubectl -n vault-system exec -i vault-0 -- vault policy write crossplane - <<EOF
 path "secret/data/*" {
     capabilities = ["create", "read", "update", "delete"]
@@ -140,132 +196,193 @@ path "secret/metadata/*" {
     capabilities = ["create", "read", "update", "delete"]
 }
 EOF
+Success! Uploaded policy: crossplane
 ```
 
-Apply the vault policy.
-```shell
+Apply the policy to Vault.
+```shell {copy-lines="1-5"}
 kubectl -n vault-system exec -it vault-0 -- vault write auth/kubernetes/role/crossplane \
     bound_service_account_names="*" \
     bound_service_account_namespaces=crossplane-system \
     policies=crossplane \
     ttl=24h
+Success! Data written to: auth/kubernetes/role/crossplane
 ```
 
-### Install and Configure Crossplane
+## Install Crossplane
 
-1. Install Crossplane by:
+{{<hint "important" >}}
+Plugin support is in the unreleased Crossplane v1.13. This guide uses a
+pre-release build with plugin support.
+{{< /hint >}}
 
-- Enabling `External Secret Stores` feature. 
-- Annotating for [Vault Agent Sidecar Injection]
+Pre-release Crossplane versions are in the Crossplane `master` repository.
 
 ```shell
-helm repo add crossplane-stable https://charts.crossplane.io/stable --force-update 
+helm repo add crossplane-master https://charts.crossplane.io/master --force-update
 ```
 
-Create the Vault configuration settings.
-```shell
-cat << EOF > values.yaml
-args:
-- --enable-external-secret-stores
-customAnnotations:
+Install the Crossplane development build version and enable the External Secrets
+Stores feature.
+
+```shell 
+helm upgrade --install crossplane crossplane-master/crossplane --devel --version 1.12.0-rc.0.284.g190ab067 --namespace crossplane-system --create-namespace --set args='{--enable-external-secret-stores}'
+```
+
+
+## Install the Crossplane Vault plugin
+
+The Crossplane Vault plugin isn't part of the default Crossplane install.
+The plugin installs as a unique Pod that uses the [Vault Agent Sidecar
+Injection] to connect the Vault secret store to Crossplane.
+
+First, configure annotations for the Vault plugin pod. 
+
+```yaml
+cat > values.yaml <<EOF
+podAnnotations:
   vault.hashicorp.com/agent-inject: "true"
   vault.hashicorp.com/agent-inject-token: "true"
-  vault.hashicorp.com/role: "crossplane"
+  vault.hashicorp.com/role: crossplane
   vault.hashicorp.com/agent-run-as-user: "65532"
-  EOF
+EOF
 ```
-
-Apply the settings to the Crossplane installation. 
-```shell 
-helm upgrade --install crossplane crossplane-stable/crossplane --namespace crossplane-system --create-namespace -f values.yaml
-```
-
-2. Create a Secret `StoreConfig` for Crossplane to be used by
-Composition types, i.e. `Composites` and `Claims`:
+Next, install the Crossplane ESS Plugin pod to the `crossplane-system` namespace 
+and apply the Vault annotations.
 
 ```shell
-echo "apiVersion: secrets.crossplane.io/v1alpha1
-kind: StoreConfig
-metadata:
-  name: vault
-spec:
-  type: Vault
-  defaultScope: crossplane-system
-  vault:
-    server: http://vault.vault-system:8200
-    mountPath: secret/
-    version: v2
-    auth:
-      method: Token
-      token:
-        source: Filesystem
-        fs:
-          path: /vault/secrets/token" | kubectl apply -f -
+helm upgrade --install ess-plugin-vault oci://xpkg.upbound.io/crossplane-contrib/ess-plugin-vault --namespace crossplane-system -f values.yaml
 ```
 
-### Install and Configure Provider GCP
+## Configure Crossplane 
 
-1. Similar to Crossplane, install Provider GCP by:
+Using the Vault plugin requires configuration to connect to the Vault
+service. The plugin also requires Providers to enable external secret stores.
 
-- Enabling `External Secret Stores` feature.
-- Annotating for [Vault Agent Sidecar Injection]
+With the plugin and providers configured, Crossplane requires two `StoreConfig` 
+objects to describe how Crossplane and the Providers communicate with vault. 
 
-```shell
+### Enable external secret stores in the Provider
+
+{{<hint "note">}}
+This example uses Provider GCP, but the 
+{{<hover label="ControllerConfig" line="2">}}ControllerConfig{{</hover>}} is the
+same for all Providers.
+{{</hint >}}
+
+Create a `ControllerConfig` object to enable external secret stores.
+
+```yaml {label="ControllerConfig"}
 echo "apiVersion: pkg.crossplane.io/v1alpha1
 kind: ControllerConfig
 metadata:
   name: vault-config
 spec:
   args:
-    - --enable-external-secret-stores
-  metadata:
-    annotations:
-      vault.hashicorp.com/agent-inject: \"true\"
-      vault.hashicorp.com/agent-inject-token: \"true\"
-      vault.hashicorp.com/role: crossplane
-      vault.hashicorp.com/agent-run-as-user: \"2000\"
----
-apiVersion: pkg.crossplane.io/v1
+    - --enable-external-secret-stores" | kubectl apply -f -
+```
+
+Install the Provider and apply the ControllerConfig.
+```yaml
+echo "apiVersion: pkg.crossplane.io/v1
 kind: Provider
 metadata:
   name: provider-gcp
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/provider-gcp:v0.22.0
+  package: xpkg.upbound.io/crossplane-contrib/provider-gcp:v0.23.0-rc.0.19.ge9b75ee5
   controllerConfigRef:
     name: vault-config" | kubectl apply -f -
 ```
 
-2. Create a Secret `StoreConfig` for Provider GCP to be used by GCP Managed
-Resources:
+### Connect the Crossplane plugin to Vault
+Create a {{<hover label="VaultConfig" line="2">}}VaultConfig{{</hover>}} 
+resource for the plugin to connect to the Vault service:
 
-```shell
-echo "apiVersion: gcp.secrets.crossplane.io/v1alpha1
+```yaml {label="VaultConfig"}
+echo "apiVersion: secrets.crossplane.io/v1alpha1
+kind: VaultConfig
+metadata:
+  name: vault-internal
+spec:
+  server: http://vault.vault-system:8200
+  mountPath: secret/
+  version: v2
+  auth:
+    method: Token
+    token:
+      source: Filesystem
+      fs:
+        path: /vault/secrets/token" | kubectl apply -f -
+```
+
+### Create a Crossplane StoreConfig
+
+Create a {{<hover label="xp-storeconfig" line="2">}}StoreConfig{{</hover >}} 
+object from the
+{{<hover label="xp-storeconfig" line="1">}}secrets.crossplane.io{{</hover >}} 
+group. Crossplane uses the StoreConfig to connect to the Vault plugin service.
+
+The {{<hover label="xp-storeconfig" line="10">}}configRef{{</hover >}} connects
+the StoreConfig to the specific Vault plugin configuration.
+
+```yaml {label="xp-storeconfig"}
+echo "apiVersion: secrets.crossplane.io/v1alpha1
 kind: StoreConfig
 metadata:
   name: vault
 spec:
-  type: Vault
+  type: Plugin
   defaultScope: crossplane-system
-  vault:
-    server: http://vault.vault-system:8200
-    mountPath: secret/
-    version: v2
-    auth:
-      method: Token
-      token:
-        source: Filesystem
-        fs:
-          path: /vault/secrets/token" | kubectl apply -f -
+  plugin:
+    endpoint: ess-plugin-vault.crossplane-system:4040
+    configRef:
+      apiVersion: secrets.crossplane.io/v1alpha1
+      kind: VaultConfig
+      name: vault-internal" | kubectl apply -f -
 ```
 
-### Deploy and Test
 
-> Prerequisite: You should have a working **default** `ProviderConfig` for
-> GCP available.
+### Create a Provider StoreConfig
+Create a {{<hover label="gcp-storeconfig" line="2">}}StoreConfig{{</hover >}} 
+object from the Provider's API group,
+{{<hover label="gcp-storeconfig" line="1">}}gcp.crossplane.io{{</hover >}}. 
+The Provider uses this StoreConfig to communicate with Vault for 
+Managed Resources.
 
-1. Create a `CompositeResourceDefinition`:
+The {{<hover label="gcp-storeconfig" line="10">}}configRef{{</hover >}} connects
+the StoreConfig to the specific Vault plugin configuration.
 
-```shell
+```yaml {label="gcp-storeconfig"}
+echo "apiVersion: gcp.crossplane.io/v1alpha1
+kind: StoreConfig
+metadata:
+  name: vault
+spec:
+  type: Plugin
+  defaultScope: crossplane-system
+  plugin:
+    endpoint: ess-plugin-vault.crossplane-system:4040
+    configRef:
+      apiVersion: secrets.crossplane.io/v1alpha1
+      kind: VaultConfig
+      name: vault-internal" | kubectl apply -f -
+```
+
+## Create Provider resources
+
+Check that Crossplane installed the Provider and the Provider is healthy.
+
+```shell {copy-lines="1"}
+kubectl get providers
+NAME           INSTALLED   HEALTHY   PACKAGE                                                                     AGE
+provider-gcp   True        True      xpkg.upbound.io/crossplane-contrib/provider-gcp:v0.23.0-rc.0.19.ge9b75ee5   10m
+```
+
+### Create a CompositeResourceDefinition
+
+Create a `CompositeResourceDefinition` to define a custom API endpoint. 
+
+```yaml
 echo "apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition
 metadata:
@@ -305,8 +422,16 @@ spec:
               - parameters" | kubectl apply -f -
 ```
 
-Create a `Composition`.
-```shell
+### Create a Composition
+Create a `Composition` to create a Service Account and Service Account Key
+inside GCP.
+
+Creating a Service Account Key generates 
+{{<hover label="comp" line="39" >}}connectionDetails{{</hover>}} that the 
+Provider stores in Vault using the 
+{{<hover label="comp" line="31">}}publishConnectionDetailsTo{{</hover>}} details.
+
+```yaml {label="comp"}
 echo "apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
@@ -350,9 +475,15 @@ spec:
         - fromConnectionSecretKey: publicKeyType" | kubectl apply -f -
 ```
 
-1. Create a `Claim`:
+### Create a Claim
+Now create a `Claim` to have Crossplane create the GCP resources and associated 
+secrets.
 
-```shell
+Like the Composition, the Claim uses 
+{{<hover label="claim" line="12">}}publishConnectionDetailsTo{{</hover>}} to
+connect to Vault and store the secrets.
+
+```yaml {label="claim"}
 echo "apiVersion: ess.example.org/v1alpha1
 kind: ESSInstance
 metadata:
@@ -374,148 +505,156 @@ spec:
       name: vault" | kubectl apply -f -
 ```
 
-3. Verify all resources SYNCED and READY:
+## Verify the resources
 
-View the managed resources.
+Verify all resources are `READY` and `SYNCED`:
+
 ```shell {copy-lines="1"}
 kubectl get managed
-# Example output:
-# NAME                                                      READY   SYNCED   DISPLAYNAME                     EMAIL                                                            DISABLED
-# serviceaccount.iam.gcp.crossplane.io/my-ess-zvmkz-vhklg   True    True     a service account to test ess   my-ess-zvmkz-vhklg@testingforbugbounty.iam.gserviceaccount.com
+NAME                                                      READY   SYNCED   DISPLAYNAME                     EMAIL                                                            DISABLED
+serviceaccount.iam.gcp.crossplane.io/my-ess-zvmkz-vhklg   True    True     a service account to test ess   my-ess-zvmkz-vhklg@testingforbugbounty.iam.gserviceaccount.com
 
-# NAME                                                         READY   SYNCED   KEY_ID                                     CREATED_AT             EXPIRES_AT
-# serviceaccountkey.iam.gcp.crossplane.io/my-ess-zvmkz-bq8pz   True    True     5cda49b7c32393254b5abb121b4adc07e140502c   2022-03-23T10:54:50Z
+NAME                                                         READY   SYNCED   KEY_ID                                     CREATED_AT             EXPIRES_AT
+serviceaccountkey.iam.gcp.crossplane.io/my-ess-zvmkz-bq8pz   True    True     5cda49b7c32393254b5abb121b4adc07e140502c   2022-03-23T10:54:50Z
 ```
 
 View the claims
 ```shell {copy-lines="1"}
 kubectl -n default get claim
-# Example output:
-# NAME     READY   CONNECTION-SECRET   AGE
-# my-ess   True                        19s
+NAME     READY   CONNECTION-SECRET   AGE
+my-ess   True                        19s
 ```
 
 View the composite resources.
 ```shell {copy-lines="1"}
 kubectl get composite
-# Example output:
-# NAME           READY   COMPOSITION                    AGE
-# my-ess-zvmkz   True    essinstances.ess.example.org   32s
+NAME           READY   COMPOSITION                    AGE
+my-ess-zvmkz   True    essinstances.ess.example.org   32s
 ```
 
-### Verify the Connection Secrets landed to Vault
+## Verify Vault secrets
 
-```shell {copy-lines="1"}
+Look inside Vault to view the secrets from the managed resources.
+
+```shell {copy-lines="1",label="vault-key"}
 kubectl -n vault-system exec -i vault-0 -- vault kv list /secret/default
-# Example output:
-# Keys
-# ----
-# ess-claim-conn
+Keys
+----
+ess-claim-conn
 ```
 
-Check connection secrets in the "crossplane-system" scope (namespace).
-```shell {copy-lines="1"}
+The key {{<hover label="vault-key" line="4">}}ess-claim-conn{{</hover>}} 
+is the name of the Claim's 
+{{<hover label="claim" line="12">}}publishConnectionDetailsTo{{</hover>}} 
+configuration.
+
+Check connection secrets in the "crossplane-system" Vault scope.
+```shell {copy-lines="1",label="scope-key"}
 kubectl -n vault-system exec -i vault-0 -- vault kv list /secret/crossplane-system
-# Example output:
-# Keys
-# ----
-# d2408335-eb88-4146-927b-8025f405da86
-# ess-mr-conn
+Keys
+----
+d2408335-eb88-4146-927b-8025f405da86
+ess-mr-conn
 ```
 
-Check contents of claim connection secret
+The key 
+{{<hover label="scope-key"line="4">}}d2408335-eb88-4146-927b-8025f405da86{{</hover>}} 
+comes from 
+
+<!-- ## WHERE DOES IT COME FROM? -->
+
+and the key 
+{{<hover label="scope-key"line="5">}}ess-mr-conn{{</hover>}} 
+comes from the Composition's
+{{<hover label="comp" line="31">}}publishConnectionDetailsTo{{</hover>}} 
+configuration.
+
+
+Check contents of Claim's connection secret `ess-claim-conn` to see the key
+created by the managed resource.
 ```shell {copy-lines="1"}
 kubectl -n vault-system exec -i vault-0 -- vault kv get /secret/default/ess-claim-conn
-# Example output:
-# ======= Metadata =======
-# Key                Value
-# ---                -----
-# created_time       2022-03-18T21:24:07.2085726Z
-# custom_metadata    map[environment:development secret.crossplane.io/owner-uid:881cd9a0-6cc6-418f-8e1d-b36062c1e108 team:backend]
-# deletion_time      n/a
-# destroyed          false
-# version            1
-# 
-# ======== Data ========
-# Key              Value
-# ---              -----
-# publicKey        -----BEGIN PUBLIC KEY-----
-# MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzsEYCokmYEsZJCc9QN/8
-# Fm1M/kTPp7Gat/MXLTP3zFyCTBFVNLN79MbAKdinWi6ePXEb75vzB79IdZcWj8lo
-# 8trnS64QjNB9Vs4Xk5UvDALwleFN/bZeperxivDPwVPvT9Aqy/U9kohoS/LHyE8w
-# uWQb5AuMeVQ1gtCTnCqQZ4d2MSVhQXYVvAWax1spJ9LT7mHub5j95xDdYIcOV3VJ
-# l9CIo4VrWIT8THFN2NnjTrGq9+0TzXY0bV674bjJkfBC6v6yXs5HTetG+Uekq/xf
-# FCjrrDi1+2UR9Mu2WTuvl8qn50be+mbwdJO5wE32jewxdYrVVmj19+PkaEeAwGTc
-# vwIDAQAB
-# -----END PUBLIC KEY-----
-# publicKeyType    TYPE_RAW_PUBLIC_KEY
+======= Metadata =======
+Key                Value
+---                -----
+created_time       2022-03-18T21:24:07.2085726Z
+custom_metadata    map[environment:development secret.crossplane.io/ner-uid:881cd9a0-6cc6-418f-8e1d-b36062c1e108 team:backend]
+deletion_time      n/a
+destroyed          false
+version            1
+
+======== Data ========
+Key              Value
+---              -----
+publicKey        -----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzsEYCokmYEsZJCc9QN/8
+Fm1M/kTPp7Gat/MXLTP3zFyCTBFVNLN79MbAKdinWi6ePXEb75vzB79IdZcWj8lo
+8trnS64QjNB9Vs4Xk5UvDALwleFN/bZeperxivDPwVPvT9Aqy/U9kohoS/LHyE8w
+uWQb5AuMeVQ1gtCTnCqQZ4d2MSVhQXYVvAWax1spJ9LT7mHub5j95xDdYIcOV3VJ
+l9CIo4VrWIT8THFN2NnjTrGq9+0TzXY0bV674bjJkfBC6v6yXs5HTetG+Uekq/xf
+FCjrrDi1+2UR9Mu2WTuvl8qn50be+mbwdJO5wE32jewxdYrVVmj19+PkaEeAwGTc
+vwIDAQAB
+-----END PUBLIC KEY-----
+publicKeyType    TYPE_RAW_PUBLIC_KEY
 ```
 
-Check contents of managed resource connection secret.
+Check contents of managed resource connection secret `ess-mr-conn`. The public
+key is identical to the public key in the Claim since the Claim is using this
+managed resource.
 ```shell {copy-lines="1"}
 kubectl -n vault-system exec -i vault-0 -- vault kv get /secret/crossplane-system/ess-mr-conn
-# Example output:
-# ======= Metadata =======
-# Key                Value
-# ---                -----
-# created_time       2022-03-18T21:21:07.9298076Z
-# custom_metadata    map[environment:development secret.crossplane.io/owner-uid:4cd973f8-76fc-45d6-ad45-0b27b5e9252a team:backend]
-# deletion_time      n/a
-# destroyed          false
-# version            2
-# 
-# ========= Data =========
-# Key               Value
-# ---               -----
-# privateKey        {
-#   "type": "service_account",
-#   "project_id": "REDACTED",
-#   "private_key_id": "REDACTED",
-#   "private_key": "-----BEGIN PRIVATE KEY-----\nREDACTED\n-----END PRIVATE KEY-----\n",
-#   "client_email": "ess-test-sa@REDACTED.iam.gserviceaccount.com",
-#   "client_id": "REDACTED",
-#   "auth_uri": "https://accounts.google.com/o/oauth2/auth",
-#   "token_uri": "https://oauth2.googleapis.com/token",
-#   "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
-#   "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/ess-test-sa%40REDACTED.iam.gserviceaccount.com"
-# }
-# privateKeyType    TYPE_GOOGLE_CREDENTIALS_FILE
-# publicKey         -----BEGIN PUBLIC KEY-----
-# MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzsEYCokmYEsZJCc9QN/8
-# Fm1M/kTPp7Gat/MXLTP3zFyCTBFVNLN79MbAKdinWi6ePXEb75vzB79IdZcWj8lo
-# 8trnS64QjNB9Vs4Xk5UvDALwleFN/bZeperxivDPwVPvT9Aqy/U9kohoS/LHyE8w
-# uWQb5AuMeVQ1gtCTnCqQZ4d2MSVhQXYVvAWax1spJ9LT7mHub5j95xDdYIcOV3VJ
-# l9CIo4VrWIT8THFN2NnjTrGq9+0TzXY0bV674bjJkfBC6v6yXs5HTetG+Uekq/xf
-# FCjrrDi1+2UR9Mu2WTuvl8qn50be+mbwdJO5wE32jewxdYrVVmj19+PkaEeAwGTc
-# vwIDAQAB
-# -----END PUBLIC KEY-----
-# publicKeyType     TYPE_RAW_PUBLIC_KEY
+======= Metadata =======
+Key                Value
+---                -----
+created_time       2022-03-18T21:21:07.9298076Z
+custom_metadata    map[environment:development secret.crossplane.io/ner-uid:4cd973f8-76fc-45d6-ad45-0b27b5e9252a team:backend]
+deletion_time      n/a
+destroyed          false
+version            2
+
+========= Data =========
+Key               Value
+---               -----
+privateKey        {
+  "type": "service_account",
+  "project_id": "REDACTED",
+  "private_key_id": "REDACTED",
+  "private_key": "-----BEGIN PRIVATE KEY-----\nREDACTED\n-----END PRIVATE KEY-----\n",
+  "client_email": "ess-test-sa@REDACTED.iam.gserviceaccount.com",
+  "client_id": "REDACTED",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/ess-test-sa%40REDACTED.iam.gserviceaccount.com"
+}
+privateKeyType    TYPE_GOOGLE_CREDENTIALS_FILE
+publicKey         -----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzsEYCokmYEsZJCc9QN/8
+Fm1M/kTPp7Gat/MXLTP3zFyCTBFVNLN79MbAKdinWi6ePXEb75vzB79IdZcWj8lo
+8trnS64QjNB9Vs4Xk5UvDALwleFN/bZeperxivDPwVPvT9Aqy/U9kohoS/LHyE8w
+uWQb5AuMeVQ1gtCTnCqQZ4d2MSVhQXYVvAWax1spJ9LT7mHub5j95xDdYIcOV3VJ
+l9CIo4VrWIT8THFN2NnjTrGq9+0TzXY0bV674bjJkfBC6v6yXs5HTetG+Uekq/xf
+FCjrrDi1+2UR9Mu2WTuvl8qn50be+mbwdJO5wE32jewxdYrVVmj19+PkaEeAwGTc
+vwIDAQAB
+-----END PUBLIC KEY-----
+publicKeyType     TYPE_RAW_PUBLIC_KEY
 ```
 
-The commands above verifies using the cli, however, you can also connect to the
-Vault UI and check secrets there.
+### Remove the resources
+
+Deleting the Claim removes the managed resources and associated keys from Vault.
 
 ```shell
-kubectl -n vault-system port-forward vault-0 8200:8200
-```
-
-Now, you can open http://127.0.0.1:8200/ui in browser and login with the root token.
-
-### Cleanup
-
-Delete the claim which should clean up all the resources created.
-
-```shell
-kubectl -n default delete claim my-ess
+kubectl delete claim my-ess
 ```
 
 <!-- named links -->
 
 [Vault]: https://www.vaultproject.io/
 [External Secret Store]: https://github.com/crossplane/crossplane/blob/master/design/design-doc-external-secret-stores.md
-[the previous guide]: {{<ref "vault-injection" >}}
 [this issue]: https://github.com/crossplane/crossplane/issues/2985
 [Kubernetes Auth Method]: https://www.vaultproject.io/docs/auth/kubernetes
 [Unseal]: https://www.vaultproject.io/docs/concepts/seal
-[Vault KV Secrets Engine]: https://www.vaultproject.io/docs/secrets/kv
+[Vault KV Secrets Engine]: https://developer.hashicorp.com/vault/docs/secrets/kv
 [Vault Agent Sidecar Injection]: https://www.vaultproject.io/docs/platform/k8s/injector
+[ESS Plugin Vault]: https://github.com/crossplane-contrib/ess-plugin-vault

--- a/utils/vale/styles/Crossplane/spelling-exceptions.txt
+++ b/utils/vale/styles/Crossplane/spelling-exceptions.txt
@@ -35,3 +35,4 @@ XRDs
 XRD's
 XRs
 Zendesk
+Hashicorp

--- a/utils/vale/styles/Google/Headings.yml
+++ b/utils/vale/styles/Google/Headings.yml
@@ -36,3 +36,10 @@ exceptions:
   - Visual
   - VS
   - Windows
+  - Vault
+  - Hashicorp
+  - StoreConfig
+  - Provider
+  - CompositeResourceDefinition
+  - Composition
+  - Claim

--- a/utils/vale/styles/Microsoft/Terms.yml
+++ b/utils/vale/styles/Microsoft/Terms.yml
@@ -5,7 +5,6 @@ ignorecase: true
 action:
   name: replace
 swap:
-  '(?:agent|virtual assistant|intelligent personal assistant)': personal digital assistant
   '(?:drive C:|drive C>|C: drive)': drive C
   '(?:internet bot|web robot)s?': bot(s)
   '(?:microsoft cloud|the cloud)': cloud

--- a/utils/vale/styles/gitlab/Uppercase.yml
+++ b/utils/vale/styles/gitlab/Uppercase.yml
@@ -17,6 +17,7 @@ exceptions:
   - ACL
   - AJAX
   - AKS
+  - ESS
   - ANSI
   - API
   - APM


### PR DESCRIPTION
This makes some structural changes (i.e., installing the plugin before the provider) and edits the headings to make them more structured. Most of the text changes are to pass Vale linting for passive voice, contractions or sentence length. 

There are two things I couldn't answer:
* Where do Provider credentials come from? Are they already in vault? 
* The vault secret in the crossplane-system scope that looks like a UID, where does it come from? (I left a comment in there to fill in).

Signed-off-by: Pete Lumbis <pete@upbound.io>	